### PR TITLE
Fix stop order loop logic

### DIFF
--- a/src/matching/price_level_order_book.cpp
+++ b/src/matching/price_level_order_book.cpp
@@ -353,14 +353,15 @@ void PriceLevelOrderBook::updateTrailingSellStopOrders() {
 }
 
 void PriceLevelOrderBook::activateStopOrders() {
-    // we keep going till all required stop orders have been activated, since activating some orders can 
+    // we keep going till all required stop orders have been activated, since activating some orders can
     // cause prices to change which inturn activates more stop orders
     bool cont = true;
     while (cont) {
-        cont = activateBuyStopOrders();
+        bool activated_buy = activateBuyStopOrders();
         updateTrailingSellStopOrders();
-        cont = activateSellStopOrders();
+        bool activated_sell = activateSellStopOrders();
         updateTrailingBuyStopOrders();
+        cont = activated_buy || activated_sell;
     }
 }
 


### PR DESCRIPTION
## Summary
- fix activation loop logic for stop orders

## Testing
- `./build.sh` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_6843be60c690832c931b45d5d10aca0b